### PR TITLE
Remove a Dockerfile cmd that breaks the image + Adding support for custom cert location.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
 	&& apt-get install -y pound \
 	&& apt-get clean \
-	&& apt-get remove --purge -y `apt-mark showauto` \
 	&& rm -rf /var/lib/apt/lists \
 	&& mkdir -p /var/run/pound \
 	&& chown -R www-data:www-data /var/run/pound

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ docker run \
     mnuessler/tls-termination-proxy
 ```
 
+### Kubernetes support
+
+When running this image on Kubernetes, the volume hosting the certificate has to be
+a directory (cannot be the file itself).
+The following command shows the alternative settings to support kubernetes volumes:
+
+```
+docker run \
+    -e HTTPS_UPSTREAM_SERVER_ADDRESS=othercontainer \
+    -e HTTPS_UPSTREAM_SERVER_PORT=80 \
+    -e CERT_PATH=/certs/cert.pem
+    -v /path/to/certs/:/certs/:ro \
+    --link othercontainer:othercontainer \
+    mnuessler/tls-termination-proxy
+```
+
+Notice that we need to configure `CERT_PATH` and make sure the volume points at the directory, not
+the cretificate file itself.
+If `CERT_PATH` is not configured, it will default to `/cert.pem`.
+
 ### Build the image
 
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-if [ ! -f "/cert.pem" ]; then
-    echo "Certificate file '/cert.pem' not found. Make sure it is mounted as a volume when starting the container."
+export CERT_PATH=${CERT_PATH:-"/cert.pem"}
+
+if [ ! -f $CERT_PATH ]; then
+    echo "Certificate file '$CERT_PATH' not found. Make sure it is mounted as a volume when starting the container."
     exit 1
 fi
 

--- a/pound.cfg
+++ b/pound.cfg
@@ -48,7 +48,7 @@ ListenHTTPS
 	# File that contains the server private key, the server
 	# certificate and (optionally) ca-certificates. The order does
 	# seem to be relevant!
-	Cert	"/cert.pem"
+	Cert	"${CERT_PATH}"
 
 	Service
 		BackEnd


### PR DESCRIPTION
I accidentally added `apt-get remove --purge -y apt-mark showauto` without noticing that it actually removes the pound package. I reverted the change to make the image function again.

I also noticed that when trying to use this image with Kubernetes, the cert volume has to be a directory, not the file itself. I added the option to define the `CERT_PATH` environment variable but made sure to keep the code compatible with the default way of defining the certificate when running through docker directly.
