### PR TITLE
Removing apt-get purge statement because it picks up the pound package when cleaning up.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
 	&& apt-get install -y pound \
 	&& apt-get clean \
-	&& apt-get remove --purge -y `apt-mark showauto` \
 	&& rm -rf /var/lib/apt/lists \
 	&& mkdir -p /var/run/pound \
 	&& chown -R www-data:www-data /var/run/pound


### PR DESCRIPTION
This issue got past me in the last pull request. I noticed that the Pound package gets cleaned up when the image in built.
