### PR TITLE
Pound Config enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ location /cert.pem by the container.
 docker run \
     -e HTTPS_UPSTREAM_SERVER_ADDRESS=othercontainer \
     -e HTTPS_UPSTREAM_SERVER_PORT=80 \
+    -e TIMEOUT=15 \
     -v /path/to/cert.pem:/cert.pem:ro \
     --link othercontainer:othercontainer \
     mnuessler/tls-termination-proxy
@@ -45,14 +46,15 @@ The following command shows the alternative settings to support kubernetes volum
 docker run \
     -e HTTPS_UPSTREAM_SERVER_ADDRESS=othercontainer \
     -e HTTPS_UPSTREAM_SERVER_PORT=80 \
-    -e CERT_PATH=/certs/cert.pem
+    -e CERT_PATH=/certs/cert.pem \
+    -e TIMEOUT=15 \
     -v /path/to/certs/:/certs/:ro \
     --link othercontainer:othercontainer \
     mnuessler/tls-termination-proxy
 ```
 
-Notice that `CERT_PATH` has to be configures and the volume has to point to a directory, not
-the cretificate file itself.
+Notice that `CERT_PATH` has to be configured and the volume has to point to a directory, not
+the certificate file itself.
 If `CERT_PATH` is not configured, it will default to `/cert.pem`.
 
 ### Build the image

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ fi
 # Environmenat variables and defaults for the configuration
 export HTTPS_UPSTREAM_SERVER_ADDRESS=${HTTPS_UPSTREAM_SERVER_ADDRESS:-"upstream"}
 export HTTPS_UPSTREAM_SERVER_PORT=${HTTPS_UPSTREAM_SERVER_PORT:-80}
+export TIMEOUT=${TIMEOUT:-15}
 
 # Prepare configuration file
 config=/etc/pound/pound.cfg

--- a/pound.cfg
+++ b/pound.cfg
@@ -25,6 +25,9 @@ LogFacility	-
 ## check backend every X secs:
 Alive		30
 
+## set timeout (defaults to 15 seconds):
+TimeOut		${TIMEOUT}
+
 ## use hardware-accelleration card supported by openssl(1):
 #SSLEngine	"<hw>"
 


### PR DESCRIPTION
Add TimeOut to pound config and expose it to env vars, this will permit users to control the time outwhen starting the docker container. It will default to 15 seconds (pond default) if env var is not passed.
@mnuessler please review. 